### PR TITLE
Bug fix : "Improper use of SMTP command pipelining"

### DIFF
--- a/mailspoof.rb
+++ b/mailspoof.rb
@@ -150,13 +150,20 @@ begin
   puts "[-] Connecting to [#{mail_server}]..."
   s = TCPSocket.new(  mail_server , 25 ) # SMTP
   puts "[-] Connected to [#{mail_server}]. Delivering mail..."
+  sleep 1
 
   s.print "HELO #{to_domain}\r\n"
   response_lines << s.gets
+  sleep 1
+  
   s.print "MAIL FROM: <#{$options[:from]}>\r\n"
   response_lines << s.gets
+  sleep 1
+  
   s.print "RCPT TO: <#{$options[:to]}>\r\n"
   response_lines << s.gets
+  sleep 1
+  
   s.print "DATA\r\n"
   response_lines << s.gets
   s.print "To: <#{$options[:to]}>\r\n"


### PR DESCRIPTION
Hello defuse, thanks for your proof of concept. 

I was facing an issue from the SMTP command pipelining.
How to reproduce : 

```
ruby mailspoof.rb --to 'test@test.com' --from 'test@test.com' --subject 'test' --organization 'test' --human-name 'test' --mail test.txt --ignore-spf
[+] Found mail server [mx1.mail.x.net]
[!] Not checking for SPF records.
[-] Connecting to [mx1.mail.x.net]...
[-] Connected to [mx1.mail.x.net]. Delivering mail...
[!] Something went wrong. I got an error code [503]. 
    The mail server said:
        220-mx1.mail.x.net in40
        220 mx1.mail.x.net in40
        250 in40.mail.x.net
        250 2.1.0 Ok
        503 5.5.0 <test@test.com>: Recipient address rejected: Improper use of SMTP command pipelining
        554 5.5.1 Error: no valid recipients
```

According to this forum : https://33hops.com/forum/viewtopic.php?id=206 : 
"Some clients report this issue very seldomly. **It is due to the SMTP server being configured with a delay in between commands. Namely, if you don't wait some time in between SMTP commands, the receving SMTP server breaks the protocol on its own.**

In case of (c)XSIBackup this can be fixed by setting the last field in the smtpsrvs.conf file to 1 (seconds) or above. One second is usually enough.

If you fell here trying to debug your own script, just add some sleep time in between SMTP commands."

Then to resolve this issue, I added `sleep 1` commands between the SMTP commands.

Regards
xzenx86